### PR TITLE
Fix pagination

### DIFF
--- a/themes/hugo-html5up-alpha/assets/sass/main.scss
+++ b/themes/hugo-html5up-alpha/assets/sass/main.scss
@@ -2187,7 +2187,9 @@ $bannerURL: "{{ (.Site.Data.homepage.banner.image | default "images/banner.jpg")
 	/* background-color: #202428; */
 	border-radius: 6px;
 
-	padding: .5em .8em;
+	display: inline-flex;
+	align-items: center;
+	padding-left: 0em;
 
 	background-color: transparent;
 
@@ -2218,8 +2220,14 @@ $bannerURL: "{{ (.Site.Data.homepage.banner.image | default "images/banner.jpg")
 }
 
 .pagination a {
+	display: inline-block;
+	padding: .5em .8em;
 	border-bottom: none;
 	color: _palette(fg-bold);
+}
+
+.pagination > li > span {
+	padding: .5em .8em;
 }
 
 


### PR DESCRIPTION
Going through the blog post pages is a little annoying since you have to click directly on the number instead of the button, so I fixed it.

Before:
![Before](https://user-images.githubusercontent.com/33849459/127786103-0c8275dc-8d6c-441b-8260-02b3cd2b0732.gif)

After:
![After](https://user-images.githubusercontent.com/33849459/127786104-e10f9a58-a9f0-4a0d-8e62-a1fed0a8e472.gif)